### PR TITLE
Emit build started service message

### DIFF
--- a/src/main/java/nu/studer/gradle/buildscan/teamcity/TeamCityBuildScanPlugin.java
+++ b/src/main/java/nu/studer/gradle/buildscan/teamcity/TeamCityBuildScanPlugin.java
@@ -13,12 +13,15 @@ public class TeamCityBuildScanPlugin implements Plugin<Project> {
     private static final String GRADLE_BUILDSCAN_TEAMCITY_PLUGIN_ENV = "GRADLE_BUILDSCAN_TEAMCITY_PLUGIN";
     private static final String BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan";
     private static final String BUILD_SCAN_SERVICE_MESSAGE_NAME = "nu.studer.teamcity.buildscan.buildScanLifeCycle";
+    private static final String BUILD_STARTED_MESSAGE = "BUILD_STARTED";
     private static final String BUILD_SCAN_SERVICE_URL_MESSAGE_ARGUMENT_PREFIX = "BUILD_SCAN_URL:";
 
     @Override
     public void apply(Project project) {
         // only register callback if this is a TeamCity build, and we are _not_ using the Gradle build runner
         if (System.getenv(TEAMCITY_VERSION_ENV) != null && System.getenv(GRADLE_BUILDSCAN_TEAMCITY_PLUGIN_ENV) == null) {
+            project.getLogger().quiet(ServiceMessage.of(BUILD_SCAN_SERVICE_MESSAGE_NAME, BUILD_STARTED_MESSAGE).toString());
+
             project.getPluginManager().withPlugin(BUILD_SCAN_PLUGIN_ID, appliedPlugin -> {
                 BuildScanExtension buildScanExtension = project.getExtensions().getByType(BuildScanExtension.class);
                 if (supportsScanPublishedListener(buildScanExtension)) {


### PR DESCRIPTION
This change updates the plugin to emit the `BUILD_STARTED` service messages that effectively tells the TeamCity plugin that this build is being "instrumented" so that in a case where no scans are published (plugin not applies, or scans disabled), we don't fall-back to scanning the entire build output looking for build scans.