### PR TITLE
Latest ge plugin test fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ configurations {
 }
 
 dependencies {
-    buildScanPlugin 'com.gradle:build-scan-plugin:2.4.2'
     gradleEnterprisePlugin 'com.gradle:gradle-enterprise-gradle-plugin:3.3.1'
 
     compileOnly 'com.gradle:gradle-enterprise-gradle-plugin:3.3.1'
@@ -65,13 +64,10 @@ bintray {
 
 test {
     environment('TEAMCITY_VERSION', '2019.1')
-    jvmArgumentProviders.add(new PluginUnderTestCommandLineArgumentProvider(buildScanPlugin: configurations.buildScanPlugin, gradleEnterprisePlugin: configurations.gradleEnterprisePlugin))
+    jvmArgumentProviders.add(new PluginUnderTestCommandLineArgumentProvider(gradleEnterprisePlugin: configurations.gradleEnterprisePlugin))
 }
 
 final class PluginUnderTestCommandLineArgumentProvider implements CommandLineArgumentProvider {
-
-    @Classpath
-    FileCollection buildScanPlugin
 
     @Classpath
     FileCollection gradleEnterprisePlugin
@@ -79,7 +75,6 @@ final class PluginUnderTestCommandLineArgumentProvider implements CommandLineArg
     @Override
     Iterable<String> asArguments() {
         [
-            "-DbuildScanPluginClasspath=${buildScanPlugin.singleFile.absolutePath}",
             "-DgradleEnterprisePluginClasspath=${gradleEnterprisePlugin.singleFile.absolutePath}"
         ]
     }


### PR DESCRIPTION
- Fixes mocked scan server to handle 2-requests publish
- Always use the Gradle Enterprise Gradle plugin (even with Gradle 5.x tests), in order to simplify even more (and remove the 1-request legacy publish mechanism)