### PR TITLE
Bump com.gradle.plugin-publish from 0.21.0 to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import static java.lang.Integer.parseInt
 
 plugins {
     id 'nu.studer.plugindev' version '4.1'
-    id 'com.gradle.plugin-publish' version '0.21.0'
+    id 'com.gradle.plugin-publish' version '1.0.0'
     id 'org.nosphere.gradle.github.actions' version '1.3.2'
     id 'groovy'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,8 @@ gradlePlugin {
     plugins {
         pluginDevPlugin {
             id = 'nu.studer.build-scan.teamcity'
+            displayName = 'gradle-build-scan-teamcity-plugin'
+            description = 'Gradle plugin for build scans that notifies TeamCity when a build scan is published during a build.'
             implementationClass = 'nu.studer.gradle.buildscan.teamcity.TeamCityBuildScanPlugin'
         }
     }
@@ -91,19 +93,7 @@ gradlePlugin {
 pluginBundle {
     website = 'https://github.com/etiennestuder/gradle-build-scan-teamcity-plugin'
     vcsUrl = 'https://github.com/etiennestuder/gradle-build-scan-teamcity-plugin'
-    description = 'Gradle plugin for build scans that notifies TeamCity when a build scan is published during a build.'
     tags = ['build scan', 'teamcity']
-
-    plugins {
-        pluginDevPlugin {
-            displayName = 'gradle-build-scan-teamcity-plugin'
-        }
-    }
-
-    mavenCoordinates {
-        groupId = 'nu.studer'
-        artifactId = 'gradle-build-scan-teamcity-plugin'
-    }
 }
 
 final class PluginUnderTestCommandLineArgumentProvider implements CommandLineArgumentProvider {


### PR DESCRIPTION
Dependabot was unable to perform an automated update of `com.gradle.plugin-publish` from 0.21.0 to 1.0.0. 

This PR updates the plugin and migrates to the new API. 

